### PR TITLE
WIP: Tests / CI

### DIFF
--- a/magellan.json
+++ b/magellan.json
@@ -1,0 +1,9 @@
+{
+  "mocha_tests": [
+    "test/spec"
+  ],
+  "mocha_opts": "test/mocha.opts",
+  "framework": "rowdy-mocha",
+  "sauce": false,
+  "browser": "phantomjs"
+}

--- a/package.json
+++ b/package.json
@@ -25,14 +25,26 @@
   "devDependencies": {
     "eslint": "^1.10.1",
     "eslint-config-defaults": "^7.1.1",
-    "eslint-plugin-filenames": "^0.2.0"
+    "eslint-plugin-filenames": "^0.2.0",
+    "expect.js": "^0.3.1",
+    "express": "^4.13.3",
+    "guacamole": "^1.1.4",
+    "mocha": "^2.3.4",
+    "phantomjs": "^1.9.18",
+    "rowdy": "^0.3.4",
+    "saucelabs": "^1.0.1",
+    "selenium-standalone": "^4.7.1",
+    "testarmada-magellan": "^3.0.3",
+    "webdriverio": "^3.2.6"
   },
   "scripts": {
     "lint-client": "eslint -c .eslintrc-client lib",
-    "lint-server": "eslint -c .eslintrc-server *.js",
-    "lint-server-test": "eslint -c .eslintrc-server-test test/js/spec test/adapters/node.js",
+    "lint-server": "eslint -c .eslintrc-server test/*.js",
+    "lint-server-test": "eslint -c .eslintrc-server-test test/spec",
     "lint": "npm run lint-client && npm run lint-server && npm run lint-server-test",
     "check": "npm run lint",
-    "check-ci": "npm run lint"
+    "check-ci": "npm run lint",
+    "install-selenium": "selenium-standalone install",
+    "test": "magellan"
   }
 }

--- a/spec/base.js
+++ b/spec/base.js
@@ -1,0 +1,70 @@
+var app = require("../server");
+
+// Magellan passes in a FUNC_PORT option for projects based on rowdy-mocha.
+// This allows for individual distinct mocking servers to be set up in parallel,
+// each with its own state. If you don't need to have individual mocking servers
+// or have started a mock (or a real server) elsewhere, the FUNC_PORT option
+// passed in by Magellan can be safely ignored by your suite.
+var PORT = process.env.FUNC_PORT || 3003;
+var HOST = process.env.TEST_HOST || "http://127.0.0.1:" + PORT;
+
+var server;
+
+var wdio = require("webdriverio");
+
+// Rowdy helpers and adapter.
+var config = require("../rowdy-config.js");
+var rowdy = require("rowdy")(config);
+var MochaAdapter = rowdy.adapters.mocha;
+
+var adapter = new MochaAdapter();
+
+// --------------------------------------------------------------------------
+// Selenium (webdriverio/Rowdy) initialization
+// --------------------------------------------------------------------------
+// We use webdriverio to get a client to Selenium, and Rowdy to help configure
+// our client, start a local selenium server if specified and provide a Mocha
+// adapter.
+
+adapter.before();
+adapter.beforeEach();
+adapter.afterEach();
+adapter.after();
+
+before(function (done) {
+  // The `adapter.before();` call has the side effect of instantiating a
+  // Selenium / WD.js client that we can extract here.
+  var client = adapter.client;
+
+  // Set a global Selenium timeout that is _before_ our test timeout.
+  client
+    .timeouts("implicit", 200)
+    .call(done);
+});
+
+// --------------------------------------------------------------------------
+// Dev. Server
+// --------------------------------------------------------------------------
+// Start up (and later stop) a single instance of the server so that we can
+// interact with the web application via our tests.
+//
+// An alternative to this approach is to hit a live running staging or
+// production server for "smoke" tests.
+//
+// For multi-file tests this setup should be extracted to a `base.spec.js`
+// file and executed **once** for the entire test suite.
+before(function (done) {
+  // Start the dev. server.
+  app.serveRoot();
+  server = app.listen(PORT, done);
+});
+
+after(function (done) {
+  if (!server) { return done(); }
+  server.close(done);
+});
+
+module.exports = {
+  adapter: adapter,
+  host: HOST
+}

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require test/setup.js

--- a/test/public/index.html
+++ b/test/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <title>Test Page</title>
+    <script src="lib/little-loader.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/rowdy-config.js
+++ b/test/rowdy-config.js
@@ -1,0 +1,217 @@
+"use strict";
+/**
+ * A base configuration.
+ *
+ * This file will automatically be loaded by rowdy if used without calling
+ * `require("rowdy")(config)`.
+ *
+ * **Default**: Do nothing and allow rowdy to auto-configure with this file.
+ *
+ * **Import & Override**: You can import this file like:
+ *
+ * ```js
+ * var config = require("rowdy/config");
+ * var config.client.logger = true;
+ * // OTHER MUTATIONS
+ * var rowdy = require("rowdy")(config);
+ * ```
+ *
+ * **Copy & Edit**: Or just copy this file to your own project and edit directly
+ * then import.
+ *
+ */
+
+// Infer Phantom path off NPM module if available.
+var PHANTOM_PATH = false;
+try {
+  /* eslint-disable global-require */
+  PHANTOM_PATH = require("phantomjs").path;
+} catch (err) {
+  // Leave false.
+}
+
+// Travis
+var BUILD = process.env.TRAVIS_BUILD_NUMBER ?
+  process.env.TRAVIS_BUILD_NUMBER + "@" + process.env.TRAVIS_COMMIT :
+  "local";
+
+// Sauce
+var SAUCE_BRANCH = process.env.TRAVIS_BRANCH || "local";
+var SAUCE_TAG = process.env.SAUCE_USERNAME + "@" + SAUCE_BRANCH;
+
+// Browser Stack
+var BROWSER_STACK_BRANCH = process.env.TRAVIS_BRANCH || "local";
+var BROWSER_STACK_TAG = process.env.BROWSER_STACK_USERNAME + "@" +
+  BROWSER_STACK_BRANCH;
+
+module.exports = {
+  /**
+   * Misc. options.
+   *
+   * Options can be globally overriden with a merge of a stringified JSON
+   * object like:
+   * ```
+   * ROWDY_OPTIONS='{ "client":{ "logger":true }, "server":{ "logger":true } }'
+   * ROWDY_OPTIONS='{ "driverLib": "wd" }'
+   * ROWDY_OPTIONS='{ "driverLib": "webdriverio" }'
+   * ```
+   */
+  options: {
+    client: {
+      logger: false,
+      port: null                // Selenium port to hit.
+    },
+    server: {
+      logger: false,
+      debug: false,
+      port: null,               // Selenium port to start on.
+      startTimeout: 10 * 1000,  // Max wait for local server to start (ms).
+      stopTimeout: 10 * 1000    // Max wait for local server to stop (ms).
+
+      // Implied Overrides
+      // -----------------
+      // start: true,
+      // phantomPath: PHANTOM_PATH
+    },
+    guacamole: {
+      // Use https://github.com/testarmada/guacamole settings?
+      // Note: Implicitly disabled if `guacmole` is not installed.
+      enabled: true
+    },
+    driverLib: "webdriverio"
+  },
+
+  /**
+   * Webdriver settings and capabilities.
+   *
+   * Select a path within this object using `ROWDY_SETTINGS="path.to.foo"`
+   * Which will then infer all of the `default` settings at that level
+   * and merge with specific fields.
+   */
+  settings: {
+    /**
+     * Local Selenium: `desiredCapabilities.browserName`
+     *
+     * Options:
+     * - "firefox",
+     * - "phantomjs"
+     * - "chrome"
+     * - "safari"
+     * - "internet explorer"
+     *
+     * See: https://code.google.com/p/selenium/wiki/DesiredCapabilities
+     */
+    local: {
+      default: {
+        desiredCapabilities: {
+          browserName: "phantomjs"
+        },
+        // These options _can_ be overriden from environment options.
+        server: {
+          start: true,
+          phantomPath: PHANTOM_PATH
+        }
+      },
+      phantomjs: {
+        desiredCapabilities: {
+          browserName: "phantomjs"
+        }
+      },
+      firefox: {
+        desiredCapabilities: {
+          browserName: "firefox"
+        }
+      },
+      chrome: {
+        desiredCapabilities: {
+          browserName: "chrome"
+        }
+      },
+      safari: {
+        desiredCapabilities: {
+          browserName: "safari"
+        }
+      },
+      ie: {
+        desiredCapabilities: {
+          browserName: "internet explorer"
+        }
+      }
+    },
+
+    /**
+     * SauceLabs.
+     *
+     * https://saucelabs.com/platforms
+     */
+    sauceLabs: {
+      default: {
+        desiredCapabilities: {
+          name: "Rowdy Tests",
+          tags: [SAUCE_TAG],
+          public: "public",
+          build: BUILD
+        },
+        remote: {
+          port: 80,
+          user: process.env.SAUCE_USERNAME,
+
+          // WD.js credentials.
+          hostname: "ondemand.saucelabs.com",
+          pwd: process.env.SAUCE_ACCESS_KEY,
+
+          // WebdriverIO credentials.
+          host: "ondemand.saucelabs.com",
+          key: process.env.SAUCE_ACCESS_KEY
+        },
+        // Custom indicator of vendor service.
+        isSauceLabs: true
+      }
+    },
+
+    /**
+     * BrowserStack.
+     *
+     * http://www.browserstack.com/automate/capabilities
+     */
+    browserStack: {
+      default: {
+        desiredCapabilities: {
+          name: BROWSER_STACK_TAG,
+          project: "Rowdy Tests",
+          build: BUILD
+        },
+        remote: {
+          port: 80,
+          user: process.env.BROWSER_STACK_USERNAME,
+
+          // WD.js credentials.
+          hostname: "hub.browserstack.com",
+          pwd: process.env.BROWSER_STACK_ACCESS_KEY,
+
+          // WebdriverIO credentials.
+          host: "hub.browserstack.com",
+          key: process.env.BROWSER_STACK_ACCESS_KEY
+        },
+        // Custom indicator of vendor service.
+        isBrowserStack: true
+      },
+      /*eslint-disable camelcase*/
+      "safari-mac": {
+        desiredCapabilities: {
+          browserName: "safari",
+          os: "OS X",
+          os_version: "Mavericks"
+        }
+      },
+      "chrome-win7": {
+        desiredCapabilities: {
+          browserName: "chrome",
+          os: "WINDOWS",
+          os_version: "7"
+        }
+      }
+      /*eslint-enable camelcase*/
+    }
+  }
+};

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,29 @@
+"use strict";
+/**
+ * Express web server.
+ */
+var express = require("express");
+var app = module.exports = express();
+var PORT = process.env.PORT || 3000;
+var _serveRoot = false;
+
+// Custom method: Add public root.
+app.serveRoot = function () {
+  if (!_serveRoot) {
+    // Server static HTML page.
+    app.use("/", express.static("test/public"));
+    app.use("/lib", express.static("lib"));
+    _serveRoot = true;
+  }
+  return app;
+};
+
+// Actually start server if script.
+/* istanbul ignore next */
+if (require.main === module) {
+  // Serve root.
+  app.serveRoot();
+
+  // Start application.
+  app.listen(PORT);
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,11 @@
+"use strict";
+/**
+ * Test setup for server-side tests.
+ */
+var expect = require("expect.js");
+
+// Add test lib globals.
+global.expect = expect;
+
+// Set test environment
+process.env.NODE_ENV = "func";

--- a/test/spec/base.js
+++ b/test/spec/base.js
@@ -1,0 +1,71 @@
+var app = require("../server");
+
+// Magellan passes in a FUNC_PORT option for projects based on rowdy-mocha.
+// This allows for individual distinct mocking servers to be set up in parallel,
+// each with its own state. If you don't need to have individual mocking servers
+// or have started a mock (or a real server) elsewhere, the FUNC_PORT option
+// passed in by Magellan can be safely ignored by your suite.
+var PORT = process.env.FUNC_PORT || 3003;
+var HOST = process.env.TEST_HOST || "http://127.0.0.1:" + PORT;
+
+var server;
+
+// FIXME: Result isn't used; does this import have side effects we need?
+require("webdriverio");
+
+// Rowdy helpers and adapter.
+var config = require("../rowdy-config.js");
+var rowdy = require("rowdy")(config);
+var MochaAdapter = rowdy.adapters.mocha;
+
+var adapter = new MochaAdapter();
+
+// --------------------------------------------------------------------------
+// Selenium (webdriverio/Rowdy) initialization
+// --------------------------------------------------------------------------
+// We use webdriverio to get a client to Selenium, and Rowdy to help configure
+// our client, start a local selenium server if specified and provide a Mocha
+// adapter.
+
+adapter.before();
+adapter.beforeEach();
+adapter.afterEach();
+adapter.after();
+
+before(function (done) {
+  // The `adapter.before();` call has the side effect of instantiating a
+  // Selenium / WD.js client that we can extract here.
+  var client = adapter.client;
+
+  // Set a global Selenium timeout that is _before_ our test timeout.
+  client
+    .timeouts("implicit", 200)
+    .call(done);
+});
+
+// --------------------------------------------------------------------------
+// Dev. Server
+// --------------------------------------------------------------------------
+// Start up (and later stop) a single instance of the server so that we can
+// interact with the web application via our tests.
+//
+// An alternative to this approach is to hit a live running staging or
+// production server for "smoke" tests.
+//
+// For multi-file tests this setup should be extracted to a `base.spec.js`
+// file and executed **once** for the entire test suite.
+before(function (done) {
+  // Start the dev. server.
+  app.serveRoot();
+  server = app.listen(PORT, done);
+});
+
+after(function (done) {
+  if (!server) { return done(); }
+  server.close(done);
+});
+
+module.exports = {
+  adapter: adapter,
+  host: HOST
+};

--- a/test/spec/little-loader.spec.js
+++ b/test/spec/little-loader.spec.js
@@ -1,0 +1,37 @@
+var base = require("./base");
+
+describe("little-loader", function () {
+  var client;
+
+  before(function () {
+    client = base.adapter.client;
+  });
+
+  // --------------------------------------------------------------------------
+  // Mocha
+  // --------------------------------------------------------------------------
+  // Set a Mocha global timeout of 10 seconds to allow for slow tests/tunnels
+  this.timeout(250000);
+
+  // --------------------------------------------------------------------------
+  // Suites
+  // --------------------------------------------------------------------------
+  describe("_lload", function () {
+    it("should be exposed on window", function (done) {
+      client
+        // Get the web application page.
+        .url(base.host)
+        // Check for our loader
+        .then(function () {
+          return this
+            .execute("return typeof window._lload")
+            .then(function (result) {
+              expect(result.value).to.be("function");
+            });
+        })
+        // ... and we're done!
+        .call(done);
+    });
+  });
+
+});


### PR DESCRIPTION
Sets up basic test infrastructure using [boilerplate-mocha-webdriverio](https://github.com/TestArmada/boilerplate-mocha-webdriverio) as a reference.

There's one example test passing, which just asserts that `window._lload` is a function.

A couple things are different from the boilerplate:

1. I found top-level `app` and `server` directories weird/misleading, as those are only for the test runner – little-loader itself doesn't have any server stuff. So I put that stuff under `test`.
2. The boilerplate doesn't actually load a JavaScript file. For now I have express serving up `lib` as well as `test/public` so we can access `little-loader.js`. We probably want to switch to loading it from a webpack-dev-server.
3. Updated `lint` commands to point to the new server & test files.

Test with:

```sh
npm run install-selenium
npm test
```

(I took out the boilerplate's `postinstall`, which breaks production installation.)

/cc @ryan-roemer 