### PR TITLE
Build minified library, add release lifecycle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,5 @@ phantomjsdriver\.log
 
 # Build
 dist
-*/dist
-build
-*/build
 coverage
-Procfile
 temp

--- a/.npmignore
+++ b/.npmignore
@@ -9,12 +9,7 @@ npm-debug\.log*
 phantomjsdriver\.log
 
 # Build
-dist
-*/dist
-build
-*/build
 coverage
-Procfile
 temp
 
 # NPM

--- a/README.md
+++ b/README.md
@@ -1,20 +1,18 @@
 Little Loader
 =============
 
-A lightweight, IE8+ JavaScript loader.
+A lightweight, IE8+ JavaScript loader that is **actually tested**...
 
 [![Travis Status][trav_img]][trav_site]
 [![Coverage Status][cov_img]][cov_site]
 
 [![Sauce Test Status][sauce_img]][sauce_site]
 
+... with a very narrow set of objectives:
 
-### Goals
-
-* Crafted to be inlined tightly in a page.
-* Tested all the way down to IE8, but not further to keep the script as small
-  as possible.
-* Reliably calls back after script loads.
+* **Tested** all the way down to IE8
+* Reliably **calls back** after script loads
+* Really, really **small** (clocking in at `~525` minified bytes)
 * ... and **that's it**!
 
 ### Usage
@@ -27,6 +25,79 @@ Little loader attaches to `window._lload` for use in your JavaScript.
     // foo.js is loaded!
   }/*, [optional context variable here] */);
 </script>
+```
+
+### Installation
+
+#### CDN
+
+For the ready-to-use version from CDN, use
+
+```html
+<!-- Minified, production version -->
+<script src="https://npmcdn.com/little-loader@VERSION/dist/little-loader.min.js"></script>
+<!-- Development version -->
+<script src="https://npmcdn.com/little-loader@VERSION/lib/little-loader.js"></script>
+```
+
+#### NPM
+
+To include `little-loader` as part of your own build, first install from `npm`:
+
+```
+$ npm install --save little-loader
+```
+
+The library presently does _not_ have a UMD wrapper, assuming instead you're
+going to inline the library. If you are using a bundler tool, here are some
+common integrations for first-class support:
+
+##### RequireJS
+
+Edit your RequireJS configuration file to include:
+
+```js
+shim: {
+  "little-loader": {
+    exports: "_lload"
+  }
+}
+```
+
+and then in your application:
+
+```js
+define(["little-loader"], function (load) {
+  load("http://example.com/foo.js", function () {
+    // foo.js is loaded!
+  }/*, [optional context variable here] */);
+});
+```
+
+##### Webpack
+
+For Webpack, you'll need to install the `exports-loader` and then edit your
+Webpack configuration file to include:
+
+```js
+module: {
+  loaders: [
+    {
+      test: require.resolve("little-loader"),
+      loader: "exports?window._lload"
+    }
+  ]
+}
+```
+
+and then in your application:
+
+```js
+var load = require("little-loader");
+
+load("http://example.com/foo.js", function () {
+  // foo.js is loaded!
+}/*, [optional context variable here] */);
 ```
 
 ### Development
@@ -52,6 +123,31 @@ $ npm run server
 
 and navigate to: http://127.0.0.1:3001/test/func/fixtures/
 
+### Releases
+
+**IMPORTANT - NPM**: To correctly run `preversion` your first step is to make
+sure that you have a very modern `npm` binary:
+
+```sh
+$ npm install -g npm
+```
+
+First, you can optionally edit and commit the project history.
+
+```sh
+$ vim HISTORY.md
+$ git add HISTORY.md
+$ git commit -m "Update history for VERSION"
+```
+
+Now we're ready to publish. Choose a semantic update for the new version.
+If you're unsure, read about semantic versioning at http://semver.org/
+
+```sh
+$ npm version VERSION|major|minor|patch -m "Version %s - INSERT_REASONS"
+```
+
+Now `postversion` will push to git and publish to NPM.
 
 [trav_img]: https://api.travis-ci.org/walmartlabs/little-loader.svg
 [trav_site]: https://travis-ci.org/walmartlabs/little-loader

--- a/lib/little-loader.js
+++ b/lib/little-loader.js
@@ -19,8 +19,12 @@
  *           ie10-dynamic-script-element-fires-loaded-readystate-prematurely
  */
 (function () {
-  // Aliases, global state.
+  // Aliases.
   var doc = document;
+  var onreadystatechange = "onreadystatechange";
+  var readyState = "readyState";
+
+  // Global state.
   var pendingScripts = {};
   var scriptCounter = 0;
 
@@ -56,22 +60,25 @@
     context = context || this;
     var script = doc.createElement("script");
 
-    if (script.readyState && !("async" in script)) {
+    // Alias: `script[readyState]` -> `script.readyState`
+    if (script[readyState] && !("async" in script)) {
       // This section is only for IE<10. Some other old browsers may
       // satisfy the above condition and enter this branch, but we don't
       // support those browsers anyway.
 
       var id = scriptCounter++;
       var isReady = { loaded: true, complete: true };
-      var isComplete = { complete: true };
       var inserted = false;
       var done = false;
 
       // Attach the handler before setting src, otherwise we might
       // miss events (consider that IE could fire them synchronously
       // upon setting src, for example).
-      script.onreadystatechange = function () {
-        if (!inserted && isReady[script.readyState]) {
+      //
+      // Alias: `script[onreadystatechange]` -> `script.onreadystatechange`
+      script[onreadystatechange] = function () {
+        // Alias: `script[readyState]` -> `script.readyState`
+        if (!inserted && isReady[script[readyState]]) {
           inserted = true;
 
           // Append to DOM.
@@ -82,9 +89,11 @@
         // after we insert (and execute) the script in the branch
         // above. So check readyState again here and react without
         // waiting for another onreadystatechange.
-        if (!done && isComplete[script.readyState]) {
+        //
+        // Alias: `script[readyState]` -> `script.readyState`
+        if (!done && script[readyState] === "complete") {
           done = true;
-          script.onreadystatechange = null;
+          script[onreadystatechange] = null;
           pendingScripts[id] = void 0;
           if (callback) {
             callback.call(context);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "little-loader",
   "version": "0.0.1",
   "description": "A lightweight, IE8+ JavaScript loader.",
-  "main": "index.js",
+  "main": "lib/little-loader.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/walmartlabs/little-loader.git"
@@ -40,6 +40,7 @@
     "selenium-standalone": "^4.7.1",
     "server-destroy": "^1.0.1",
     "testarmada-magellan": "^3.0.3",
+    "uglify-js": "^2.6.1",
     "webdriverio": "^3.2.6"
   },
   "scripts": {
@@ -61,6 +62,10 @@
     "check": "npm run lint && npm run test",
     "check-ci": "npm run lint && npm run test-ci",
     "server": "http-server -p 3001 .",
-    "install-dev": "selenium-standalone install"
+    "install-dev": "selenium-standalone install",
+    "build": "rimraf dist && mkdir dist && uglifyjs lib/little-loader.js --stats --compress --mangle --output=dist/little-loader.min.js",
+    "preversion": "npm run check",
+    "version": "npm run build",
+    "postversion": "git push && git push --tags && npm publish"
   }
 }


### PR DESCRIPTION
Fixes #10

* Build minified dist/
* Optimize code for compression. I've done some hand-tooled tricks with string aliases for `onreadystatechange` and `readyState` for better minification. It's slightly harder to read, but not much. I didn't go for the final bytes that would have made the underlying code too unreadable.
* Update docs for release/build tool integration
* Add npm 'version' lifecycle commands

**Note**: I'm **not** planning on doing a UMD wrapper ( #9 ), instead giving documentation of how to build with "the usual tools" to have a laser-light focus on tightly inlining this.

We're down to `525` bytes with Uglify! Also note that although Closure Compiler goes smaller at `519` bytes, the `6` bytes difference doesn't make it worth the cost of having Java in the publishing pipeline.

... after this we should be ready for rollout to Atlas and beyond!

```sh
$ npm run build
$ wc -c dist/little-loader.min.js 
     525 dist/little-loader.min.js
```

/cc @exogen @baer @aisapatino @geekdave @Maciek416