### PR TITLE
Add load error capturing for callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A lightweight, IE8+ JavaScript loader that is **actually tested**...
 
 * **Tested** all the way down to IE8
 * Reliably **calls back** after script loads
-* Really, really **small** (clocking in at `~666` minified bytes)
+* Captures script load **errors** down to IE8
+* Really, really **small** (clocking in at `~865` minified bytes)
 * ... and **that's it**!
 
 We currently test:
@@ -29,8 +30,9 @@ Alone, little loader attaches to `window._lload` for loading your Javascript:
 
 ```html
 <script>
-  window._lload("http://example.com/foo.js", function () {
-    // foo.js is loaded!
+  window._lload("http://example.com/foo.js", function (err) {
+    // `err` is script load error.
+    // otherwise, foo.js is loaded!
   }/*, [optional context (`this`) variable here] */);
 </script>
 ```
@@ -39,9 +41,9 @@ If you use an AMD bundling tool (like RequireJS):
 
 ```js
 define(["little-loader"], function (load) {
-  load("http://example.com/foo.js", function () {
-    // foo.js is loaded!
-  }/*, [optional context (`this`) variable here] */);
+  load("http://example.com/foo.js", function (err) {
+    // ... your code ...
+  });
 });
 ```
 
@@ -50,9 +52,9 @@ If you use a CommonJS bundling tool (like Webpack):
 ```js
 var load = require("little-loader");
 
-load("http://example.com/foo.js", function () {
-  // foo.js is loaded!
-}/*, [optional context (`this`) variable here] */);
+load("http://example.com/foo.js", function (err) {
+  // ... your code ...
+});
 ```
 
 ### Installation

--- a/lib/little-loader.js
+++ b/lib/little-loader.js
@@ -22,6 +22,7 @@
   // Aliases.
   var doc = document;
   var onreadystatechange = "onreadystatechange";
+  var onerror = "onerror";
   var readyState = "readyState";
 
   // Global state.
@@ -56,11 +57,50 @@
    * @returns {void}
    */
   var _lload = function (src, callback, context) {
-    /*eslint max-statements: [2, 20]*/
+    /*eslint max-statements: [2, 25]*/
     var script = doc.createElement("script");
+    var done = false;
+    var err;
+    var _finish; // _must_ be set below.
+
+    /**
+     * Error handler
+     *
+     * @returns {void}
+     */
+    var _error = function () {
+      err = new Error(src || "EMPTY");
+      _finish();
+    };
+
+    /**
+     * Create handler for error or completion.
+     *
+     * **Note**: Will only be called _once_.
+     *
+     * @param {Function}  finishCb Internal state cleanup.
+     * @returns {Function}         Callback wrapper
+     */
+    var _createFinish = function (finishCb) {
+      return function () {
+        // Only call once.
+        if (done) { return; }
+        done = true;
+
+        // Internal cleanup.
+        finishCb();
+
+        // Callback.
+        if (callback) {
+          callback.call(context, err);
+        }
+      };
+    };
 
     // Alias: `script[readyState]` -> `script.readyState`
     if (script[readyState] && !("async" in script)) {
+      /*eslint-disable consistent-return*/
+
       // This section is only for IE<10. Some other old browsers may
       // satisfy the above condition and enter this branch, but we don't
       // support those browsers anyway.
@@ -68,7 +108,12 @@
       var id = scriptCounter++;
       var isReady = { loaded: true, complete: true };
       var inserted = false;
-      var done = false;
+
+      // Clear out listeners, state.
+      _finish = _createFinish(function () {
+        script[onreadystatechange] = script[onerror] = null;
+        pendingScripts[id] = void 0;
+      });
 
       // Attach the handler before setting src, otherwise we might
       // miss events (consider that IE could fire them synchronously
@@ -76,12 +121,59 @@
       //
       // Alias: `script[onreadystatechange]` -> `script.onreadystatechange`
       script[onreadystatechange] = function () {
+        var firstState = script[readyState];
+
+        // Protect against any errors from state change randomness.
+        if (err) { return; }
+
         // Alias: `script[readyState]` -> `script.readyState`
-        if (!inserted && isReady[script[readyState]]) {
+        if (!inserted && isReady[firstState]) {
           inserted = true;
 
           // Append to DOM.
           _addScript(script);
+        }
+
+        // --------------------------------------------------------------------
+        //                       GLORIOUS IE8 HACKAGE!!!
+        // --------------------------------------------------------------------
+        //
+        // Oh IE8, how you disappoint. IE8 won't call `script.onerror`, so
+        // we have to resort to drastic measures.
+        // See, e.g. http://www.quirksmode.org/dom/events/error.html#t02
+        //
+        // As with all things development, there's a Stack Overflow comment that
+        // asserts the following combinations of state changes in IE8 indicate a
+        // script load error. And crazily, it seems to work!
+        //
+        // http://stackoverflow.com/a/18840568/741892
+        //
+        // The `script.readyState` transitions we're interested are:
+        //
+        // * If state starts as `loaded`
+        // * Call `script.children`, which _should_ change state to `complete`
+        // * If state is now `loading`, then **we have a load error**
+        //
+        // For the reader's amusement, here is HeadJS's catalog of various
+        // `readyState` transitions in normal operation for IE:
+        // https://github.com/headjs/headjs/blob/master/src/2.0.0/load.js#L379-L419
+        if (firstState === "loaded") {
+          // The act of accessing the property should change the script's
+          // `readyState`.
+          //
+          // And, oh yeah, this hack is so hacky-ish we need the following
+          // eslint disable...
+          /*eslint-disable no-unused-expressions*/
+          script.children;
+          /*eslint-enable no-unused-expressions*/
+
+          if (script[readyState] === "loading") {
+            // State transitions indicate we've hit the load error.
+            //
+            // **Note**: We are not intending to _return_ a value, just have
+            // a shorter short-circuit code path here.
+            return _error();
+          }
         }
 
         // It's possible for readyState to be "complete" immediately
@@ -90,16 +182,15 @@
         // waiting for another onreadystatechange.
         //
         // Alias: `script[readyState]` -> `script.readyState`
-        if (!done && script[readyState] === "complete") {
-          done = true;
-          script[onreadystatechange] = null;
-          pendingScripts[id] = void 0;
-          if (callback) {
-            callback.call(context);
-          }
+        if (script[readyState] === "complete") {
+          _finish();
         }
-
       };
+
+      // Onerror handler _may_ work here.
+      //
+      // Alias: `script[onerror]` -> `script.onerror`
+      script[onerror] = _error;
 
       // Since we're not appending the script to the DOM yet, the
       // reference to our script element might get garbage collected
@@ -119,13 +210,13 @@
     } else {
       // This section is for modern browsers, including IE10+.
 
-      if (callback) {
-        script.onload = function () {
-          script.onload = null;
-          callback.call(context);
-        };
-      }
+      // Clear out listeners.
+      _finish = _createFinish(function () {
+        script.onload = script[onerror] = null;
+      });
 
+      script[onerror] = _error;
+      script.onload = _finish;
       script.async = true;
       script.charset = "utf-8";
       script.src = src;

--- a/test/client/requirejs/spec/error.spec.js
+++ b/test/client/requirejs/spec/error.spec.js
@@ -1,0 +1,21 @@
+define(["lib/little-loader"], function (load) {
+  describe("requirejs:error", function () {
+
+    it("errs on 404", function (done) {
+      load("DOESNT_EXIST.js", function (err) {
+        expect(err).to.be.ok;
+        expect(err.message || err.toString()).to.contain("DOESNT_EXIST.js");
+        done();
+      });
+    });
+
+    it("errs on undefined url", function (done) {
+      load(undefined, function (err) {
+        expect(err).to.be.ok;
+        expect(err.message || err.toString()).to.contain("EMPTY");
+        done();
+      });
+    });
+
+  });
+});

--- a/test/client/webpack/spec/error.spec.js
+++ b/test/client/webpack/spec/error.spec.js
@@ -1,0 +1,21 @@
+var load = require("lib/little-loader");
+
+describe("webpack:error", function () {
+
+  it("errs on 404", function (done) {
+    load("DOESNT_EXIST.js", function (err) {
+      expect(err).to.be.ok;
+      expect(err.message || err.toString()).to.contain("DOESNT_EXIST.js");
+      done();
+    });
+  });
+
+  it("errs on undefined url", function (done) {
+    load(undefined, function (err) {
+      expect(err).to.be.ok;
+      expect(err.message || err.toString()).to.contain("EMPTY");
+      done();
+    });
+  });
+
+});

--- a/test/func/fixtures/error.html
+++ b/test/func/fixtures/error.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixture</title>
+  </head>
+  <body>
+    <div class="e2e-content"></div>
+    <div class="e2e-error"></div>
+    <script src="error-handler.js"></script>
+    <script src="../../../lib/little-loader.js"></script>
+    <script>
+      // Load a non-existent page.
+      window._lload("DOESNT_EXIST.js", function (err) {
+        var content = document.querySelector(".e2e-content");
+        content.innerHTML +=
+          "<div class='e2e-after-load'>" +
+          (err ? err.message || err.toString() : "NO_ERROR") +
+          "</div>";
+      });
+    </script>
+  </body>
+</html>

--- a/test/func/spec/error.spec.js
+++ b/test/func/spec/error.spec.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var base = require("./base.spec");
+
+describe("error", function () {
+  it("capture script 404 error", function (done) {
+    var url = base.appUrl + "test/func/fixtures/error.html";
+
+    base.adapter.client
+      .url(url)
+
+      // Check errors
+      .getText(".e2e-error").then(function (text) {
+        expect(text).to.not.be.ok;
+      })
+
+      // Verify error callback
+      .getText(".e2e-after-load").then(function (text) {
+        expect(text).to.equal("DOESNT_EXIST.js");
+      })
+
+      .finally(base.promiseDone(done));
+  });
+});


### PR DESCRIPTION
Holy moly, it works!!!

Fixes #15

* Use script.onerror for IE9+
* Use horrible hack for IE8
* Add unit and functional tests
* Update documentation and byte size

/cc @exogen @PeoB @aisapatino @baer 