### PR TITLE
Add live jquery tests. Add err callback asserts for unit tests.

### DIFF
--- a/test/client/requirejs/spec/advanced.spec.js
+++ b/test/client/requirejs/spec/advanced.spec.js
@@ -6,16 +6,20 @@ define(["lib/little-loader"], function (load) {
     });
 
     it("loads nested scripts", function (done) {
-      load("/base/test/client/fixtures/advanced/one.js", function () {
+      load("/base/test/client/fixtures/advanced/one.js", function (err1) {
+        expect(err1).to.not.be.ok;
         expect(window._LLOAD_TEST.one).to.equal("one");
 
-        load("/base/test/client/fixtures/advanced/two.js", function () {
+        load("/base/test/client/fixtures/advanced/two.js", function (err2) {
+          expect(err2).to.not.be.ok;
           expect(window._LLOAD_TEST.two).to.equal("two");
 
-          load("/base/test/client/fixtures/advanced/three.js", function () {
+          load("/base/test/client/fixtures/advanced/three.js", function (err3) {
+            expect(err3).to.not.be.ok;
             expect(window._LLOAD_TEST.three).to.equal("three");
 
-            load("/base/test/client/fixtures/advanced/four.js", function () {
+            load("/base/test/client/fixtures/advanced/four.js", function (err4) {
+              expect(err4).to.not.be.ok;
               expect(window._LLOAD_TEST.four).to.equal("four");
               done();
             });
@@ -25,13 +29,16 @@ define(["lib/little-loader"], function (load) {
     });
 
     it("loads requirejs callback to load", function (done) {
-      load("/base/test/client/fixtures/advanced/one.js", function () {
+      load("/base/test/client/fixtures/advanced/one.js", function (err1) {
+        expect(err1).to.not.be.ok;
         expect(window._LLOAD_TEST.one).to.equal("one");
 
-        load("/base/test/client/fixtures/advanced/two.js", function () {
+        load("/base/test/client/fixtures/advanced/two.js", function (err2) {
+          expect(err2).to.not.be.ok;
           expect(window._LLOAD_TEST.two).to.equal("two");
 
-          load("/base/test/client/fixtures/advanced/three.amd.js", function () {
+          load("/base/test/client/fixtures/advanced/three.amd.js", function (err3) {
+            expect(err3).to.not.be.ok;
             expect(window._LLOAD_TEST.three).to.equal("three");
 
             window._LLOAD_TEST.getFour(function () {

--- a/test/client/requirejs/spec/basic.spec.js
+++ b/test/client/requirejs/spec/basic.spec.js
@@ -6,7 +6,8 @@ define(["lib/little-loader"], function (load) {
     });
 
     it("loads basic", function (done) {
-      load("/base/test/client/fixtures/basic/basic.js", function () {
+      load("/base/test/client/fixtures/basic/basic.js", function (err) {
+        expect(err).to.not.be.ok;
         expect(window._LLOAD_TEST).to.be.ok;
         expect(window._LLOAD_TEST.basic).to.equal("basic");
         done();
@@ -16,7 +17,8 @@ define(["lib/little-loader"], function (load) {
     it("uses context", function (done) {
       var obj = { greeting: "hi" };
 
-      load("/base/test/client/fixtures/basic/basic.js", function () {
+      load("/base/test/client/fixtures/basic/basic.js", function (err) {
+        expect(err).to.not.be.ok;
         expect(this.greeting).to.equal("hi");
         done();
       }, obj);

--- a/test/client/webpack/spec/advanced.spec.js
+++ b/test/client/webpack/spec/advanced.spec.js
@@ -7,16 +7,20 @@ describe("webpack:advanced", function () {
   });
 
   it("loads nested scripts", function (done) {
-    load("/base/test/client/fixtures/advanced/one.js", function () {
+    load("/base/test/client/fixtures/advanced/one.js", function (err1) {
+      expect(err1).to.not.be.ok;
       expect(window._LLOAD_TEST.one).to.equal("one");
 
-      load("/base/test/client/fixtures/advanced/two.js", function () {
+      load("/base/test/client/fixtures/advanced/two.js", function (err2) {
+        expect(err2).to.not.be.ok;
         expect(window._LLOAD_TEST.two).to.equal("two");
 
-        load("/base/test/client/fixtures/advanced/three.js", function () {
+        load("/base/test/client/fixtures/advanced/three.js", function (err3) {
+          expect(err3).to.not.be.ok;
           expect(window._LLOAD_TEST.three).to.equal("three");
 
-          load("/base/test/client/fixtures/advanced/four.js", function () {
+          load("/base/test/client/fixtures/advanced/four.js", function (err4) {
+            expect(err4).to.not.be.ok;
             expect(window._LLOAD_TEST.four).to.equal("four");
             done();
           });

--- a/test/client/webpack/spec/basic.spec.js
+++ b/test/client/webpack/spec/basic.spec.js
@@ -7,7 +7,8 @@ describe("webpack:basic", function () {
   });
 
   it("loads basic", function (done) {
-    load("/base/test/client/fixtures/basic/basic.js", function () {
+    load("/base/test/client/fixtures/basic/basic.js", function (err) {
+      expect(err).to.not.be.ok;
       expect(window._LLOAD_TEST).to.be.ok;
       expect(window._LLOAD_TEST.basic).to.equal("basic");
       done();
@@ -17,7 +18,8 @@ describe("webpack:basic", function () {
   it("uses context", function (done) {
     var obj = { greeting: "hi" };
 
-    load("/base/test/client/fixtures/basic/basic.js", function () {
+    load("/base/test/client/fixtures/basic/basic.js", function (err) {
+      expect(err).to.not.be.ok;
       expect(this.greeting).to.equal("hi");
       done();
     }, obj);

--- a/test/func/fixtures/jquery.html
+++ b/test/func/fixtures/jquery.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixture</title>
+  </head>
+  <body>
+    <div class="e2e-content"></div>
+    <div class="e2e-error"></div>
+    <script src="error-handler.js"></script>
+    <script src="../../../lib/little-loader.js"></script>
+    <script src="jquery/jquery.js"></script>
+  </body>
+</html>

--- a/test/func/fixtures/jquery/jquery.js
+++ b/test/func/fixtures/jquery/jquery.js
@@ -1,0 +1,72 @@
+(function () {
+  // These are "live" tests meaning you need an internet connection.
+  var load = window._lload;
+  var content = document.querySelector(".e2e-content");
+
+  // DOM writing helper
+  var output = function (name, err, result) {
+    content.innerHTML +=
+      "<div class='e2e-" + name + "-error'>" +
+        (err ? err.message || err.toString() : "") +
+      "</div>" +
+
+      "<div class='e2e-" + name + "-result'>" +
+        (result || "") +
+      "</div>";
+  };
+
+  // Append status information of jQuery noConflict state to DOM content.
+  var check = function (host, version, extra) {
+    var name = [host, version.replace(/\./g, "-"), extra].join("-");
+    var url = host === "google" ?
+      "http://ajax.googleapis.com/ajax/libs/jquery/" + version + "/jquery.min.js" :
+      "http://code.jquery.com/jquery-" + version + ".min.js";
+
+    load(url, function (err) {
+      var results = "";
+
+      if (typeof window.jQuery !== "function") {
+        results += "FAIL: jquery function, ";
+      }
+
+      // Remove the global.
+      var jQuery = window.jQuery.noConflict(true);
+
+      if (typeof jQuery._MARKED !== "undefined") {
+        results += "FAIL: jquery marked, ";
+      }
+
+      if (jQuery.fn.jquery !== version) {
+        results += "FAIL: jquery version ( " +
+          jQuery.fn.jquery + " vs. " + version + "), ";
+      }
+
+      // Mark the instance with a flag.
+      jQuery._MARKED = true;
+
+      // Pass
+      if (!results) {
+        results = "PASS";
+      }
+
+      output(name, err, results);
+    });
+  };
+
+  // Run a whole bunch of loads.
+  check("google", "1.11.3", "1");
+  check("jquery", "1.11.3", "1");
+
+  check("google", "1.11.2", "1");
+  check("jquery", "1.11.2", "1");
+
+  check("jquery", "1.7.2", "1");
+
+  check("google", "1.11.1", "1");
+  check("jquery", "1.11.1", "1");
+
+  check("google", "1.7.2", "1");
+
+  check("google", "1.11.3", "2");
+  check("jquery", "1.11.3", "2");
+}());

--- a/test/func/spec/jquery.spec.js
+++ b/test/func/spec/jquery.spec.js
@@ -1,0 +1,90 @@
+"use strict";
+
+var base = require("./base.spec");
+
+describe("error", function () {
+  it("handles multiple jqueries", function (done) {
+    var url = base.appUrl + "test/func/fixtures/jquery.html";
+
+    base.adapter.client
+      .url(url)
+
+      // Check errors
+      .getText(".e2e-error").then(function (text) {
+        expect(text).to.not.be.ok;
+      })
+
+      // Verify error and result callbacks
+      .getText(".e2e-google-1-11-3-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-11-3-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-google-1-11-3-2-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-11-3-2-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-google-1-11-1-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-11-1-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-google-1-7-2-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-7-2-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-11-3-2-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-11-3-2-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-11-2-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-11-2-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-7-2-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-7-2-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-11-1-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-11-1-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-google-1-11-2-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-11-2-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-11-3-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-11-3-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .finally(base.promiseDone(done));
+  });
+});

--- a/test/func/spec/jquery.spec.js
+++ b/test/func/spec/jquery.spec.js
@@ -22,52 +22,10 @@ describe("error", function () {
         expect(text).to.equal("PASS");
       })
 
-      .getText(".e2e-google-1-11-3-2-error").then(function (text) {
+      .getText(".e2e-jquery-1-11-3-1-error").then(function (text) {
         expect(text).to.equal("");
       })
-      .getText(".e2e-google-1-11-3-2-result").then(function (text) {
-        expect(text).to.equal("PASS");
-      })
-
-      .getText(".e2e-google-1-11-1-1-error").then(function (text) {
-        expect(text).to.equal("");
-      })
-      .getText(".e2e-google-1-11-1-1-result").then(function (text) {
-        expect(text).to.equal("PASS");
-      })
-
-      .getText(".e2e-google-1-7-2-1-error").then(function (text) {
-        expect(text).to.equal("");
-      })
-      .getText(".e2e-google-1-7-2-1-result").then(function (text) {
-        expect(text).to.equal("PASS");
-      })
-
-      .getText(".e2e-jquery-1-11-3-2-error").then(function (text) {
-        expect(text).to.equal("");
-      })
-      .getText(".e2e-jquery-1-11-3-2-result").then(function (text) {
-        expect(text).to.equal("PASS");
-      })
-
-      .getText(".e2e-jquery-1-11-2-1-error").then(function (text) {
-        expect(text).to.equal("");
-      })
-      .getText(".e2e-jquery-1-11-2-1-result").then(function (text) {
-        expect(text).to.equal("PASS");
-      })
-
-      .getText(".e2e-jquery-1-7-2-1-error").then(function (text) {
-        expect(text).to.equal("");
-      })
-      .getText(".e2e-jquery-1-7-2-1-result").then(function (text) {
-        expect(text).to.equal("PASS");
-      })
-
-      .getText(".e2e-jquery-1-11-1-1-error").then(function (text) {
-        expect(text).to.equal("");
-      })
-      .getText(".e2e-jquery-1-11-1-1-result").then(function (text) {
+      .getText(".e2e-jquery-1-11-3-1-result").then(function (text) {
         expect(text).to.equal("PASS");
       })
 
@@ -78,12 +36,55 @@ describe("error", function () {
         expect(text).to.equal("PASS");
       })
 
-      .getText(".e2e-jquery-1-11-3-1-error").then(function (text) {
+      .getText(".e2e-jquery-1-11-2-1-error").then(function (text) {
         expect(text).to.equal("");
       })
-      .getText(".e2e-jquery-1-11-3-1-result").then(function (text) {
+      .getText(".e2e-jquery-1-11-2-1-result").then(function (text) {
         expect(text).to.equal("PASS");
       })
+
+      .getText(".e2e-google-1-7-2-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-7-2-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-google-1-11-1-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-11-1-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-11-1-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-11-1-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-7-2-1-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-7-2-1-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-google-1-11-3-2-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-google-1-11-3-2-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
+      .getText(".e2e-jquery-1-11-3-2-error").then(function (text) {
+        expect(text).to.equal("");
+      })
+      .getText(".e2e-jquery-1-11-3-2-result").then(function (text) {
+        expect(text).to.equal("PASS");
+      })
+
 
       .finally(base.promiseDone(done));
   });


### PR DESCRIPTION
* Implements the jquery multiple load tests in https://github.com/exogen/script-atomic-onload/blob/master/test/spec/loadScript.spec.js as functional tests for `little-loader`
* Adds `err` assertions for all unit tests.

/cc @exogen @aisapatino @baer 